### PR TITLE
fix: update API endpoint paths for sequencing

### DIFF
--- a/cgi_clinics_api/analysis.py
+++ b/cgi_clinics_api/analysis.py
@@ -596,7 +596,7 @@ def create_direct_analysis(
 # region DELETE
 
 
-def delete_analysis(project_uuid: str, analysis_uuid: str, main_headers: dict[str, str]) -> dict:
+def delete_analysis(project_uuid: str, analysis_uuid: str, main_headers: dict[str, str]) -> None:
     """Delete an analysis from the new CGI-Clinics Platform.
 
     Parameters
@@ -610,8 +610,8 @@ def delete_analysis(project_uuid: str, analysis_uuid: str, main_headers: dict[st
 
     Returns
     -------
-    dict
-        A dictionary containing the analysis information.
+    None
+        This function doesn't return anything.
 
     Raises
     ------
@@ -628,8 +628,7 @@ def delete_analysis(project_uuid: str, analysis_uuid: str, main_headers: dict[st
         print(f"Failed to delete analysis: {response.status_code} - {response.text}")
         raise requests.exceptions.HTTPError(f"Failed to delete analysis: {response.status_code} - {response.text}")
     print(f"Analysis deleted successfully: {analysis_uuid}")
-
-    return response.json()
+    return None
 
 
 # endregion DELETE

--- a/cgi_clinics_api/patient.py
+++ b/cgi_clinics_api/patient.py
@@ -436,7 +436,7 @@ def update_patient(
 # region DELETE
 
 
-def delete_patient(project_uuid: str, patient_uuid: str, main_headers: dict[str, str]) -> dict:
+def delete_patient(project_uuid: str, patient_uuid: str, main_headers: dict[str, str]) -> None:
     """Delete a patient from the new CGI-Clinics Platform.
 
     Parameters
@@ -450,8 +450,8 @@ def delete_patient(project_uuid: str, patient_uuid: str, main_headers: dict[str,
 
     Returns
     -------
-    dict
-        A dictionary containing the deleted patient information.
+    None
+        This function doesn't return anything.
 
     Raises
     ------
@@ -468,8 +468,7 @@ def delete_patient(project_uuid: str, patient_uuid: str, main_headers: dict[str,
         print(f"Failed to delete patient: {response.status_code} - {response.text}")
         raise requests.exceptions.HTTPError(f"Failed to delete patient: {response.status_code} - {response.text}")
     print(f"Patient deleted successfully with ID: {patient_uuid}")
-
-    return response.json()
+    return None
 
 
 # endregion DELETE

--- a/cgi_clinics_api/project.py
+++ b/cgi_clinics_api/project.py
@@ -172,7 +172,7 @@ def create_project(project_name: str, main_headers: dict[str, str]) -> dict:
 # region DELETE
 
 
-def delete_project(project_uuid: str, main_headers: dict[str, str]) -> dict:
+def delete_project(project_uuid: str, main_headers: dict[str, str]) -> None:
     """Delete a project from the new CGI-Clinics Platform.
 
     Parameters
@@ -184,8 +184,8 @@ def delete_project(project_uuid: str, main_headers: dict[str, str]) -> dict:
 
     Returns
     -------
-    dict
-        A dictionary containing the project information.
+    None
+        This function doesn't return anything.
 
     Raises
     ------
@@ -200,8 +200,7 @@ def delete_project(project_uuid: str, main_headers: dict[str, str]) -> dict:
         print(f"Failed to delete project: {response.status_code} - {response.text}")
         raise requests.exceptions.HTTPError(f"Failed to delete project: {response.status_code} - {response.text}")
     print(f"Project deleted successfully: {project_uuid}")
-
-    return response.json()
+    return None
 
 
 # endregion DELETE

--- a/cgi_clinics_api/sample.py
+++ b/cgi_clinics_api/sample.py
@@ -385,7 +385,7 @@ def update_sample(
 
 
 # region DELETE
-def delete_sample(project_uuid: str, sample_uuid: str, main_headers: dict[str, str]) -> dict:
+def delete_sample(project_uuid: str, sample_uuid: str, main_headers: dict[str, str]) -> None:
     """Delete a sample from the new CGI-Clinics Platform.
 
     Parameters
@@ -399,8 +399,8 @@ def delete_sample(project_uuid: str, sample_uuid: str, main_headers: dict[str, s
 
     Returns
     -------
-    dict
-        A dictionary containing the deleted sample information.
+    None
+        This function doesn't return anything.
 
     Raises
     ------
@@ -417,10 +417,8 @@ def delete_sample(project_uuid: str, sample_uuid: str, main_headers: dict[str, s
     if not 200 <= response.status_code < 300:
         print(f"Failed to delete sample (Error {response.status_code}): {response.text}")
         raise requests.exceptions.HTTPError(f"Failed to delete sample (Error {response.status_code}): {response.text}")
-
     print(f"Sample deleted successfully: {sample_uuid}")
-
-    return response.json()
+    return None
 
 
 # endregion DELETE

--- a/cgi_clinics_api/sequencing.py
+++ b/cgi_clinics_api/sequencing.py
@@ -108,7 +108,7 @@ def get_all_sequencings_paginated(
         "page": page,
     }
     response: requests.Response = requests.get(
-        f"https://v2.cgiclinics.eu/api/1.0/{project_uuid}/sequencing", headers=main_headers, timeout=20, params=params
+        f"https://v2.cgiclinics.eu/api/1.0/project/{project_uuid}/sequencing", headers=main_headers, timeout=20, params=params
     )
     if not 200 <= response.status_code < 300:
         print(f"Failed to get sequencings (Error {response.status_code}): {response.text}")
@@ -148,7 +148,7 @@ def get_sequencing_by_uuid(
     """
     print("Fetching sequencing by UUID")
     response: requests.Response = requests.get(
-        f"https://v2.cgiclinics.eu/api/1.0/{project_uuid}/sequencing/{sequencing_uuid}",
+        f"https://v2.cgiclinics.eu/api/1.0/project/{project_uuid}/sequencing/{sequencing_uuid}",
         headers=main_headers,
         timeout=20,
     )
@@ -157,7 +157,7 @@ def get_sequencing_by_uuid(
         raise requests.exceptions.HTTPError(
             f"Failed to get sequencings (Error {response.status_code}): {response.text}"
         )
-    print(f"Sequencings retrieved successfully: {len(response.json())} sequencings found")
+    print("Sequencing retrieved successfully")
 
     return response.json()
 
@@ -238,7 +238,7 @@ def create_sequencing(
 
     # Make the API request
     response: requests.Response = requests.post(
-        f"https://v2.cgiclinics.eu/api/1.0/{project_uuid}/sequencing/{sequencing_uuid}",
+        f"https://v2.cgiclinics.eu/api/1.0/project/{project_uuid}/sequencing/{sequencing_uuid}",
         headers=main_headers,
         json=sequencing_data,
         timeout=20,
@@ -330,7 +330,7 @@ def update_sequencing(
     }
     # Make the API request
     response: requests.Response = requests.put(
-        f"https://v2.cgiclinics.eu/api/1.0/{project_uuid}/sequencing/{sequencing_uuid}",
+        f"https://v2.cgiclinics.eu/api/1.0/project/{project_uuid}/sequencing/{sequencing_uuid}",
         headers=main_headers,
         json=sequencing_data,
         timeout=20,
@@ -380,7 +380,7 @@ def delete_sequencing(
     """
     print(f"Deleting sequencing: {sequencing_uuid}")
     response: requests.Response = requests.delete(
-        f"https://v2.cgiclinics.eu/api/1.0/{project_uuid}/sequencing/{sequencing_uuid}",
+        f"https://v2.cgiclinics.eu/api/1.0/project/{project_uuid}/sequencing/{sequencing_uuid}",
         headers=main_headers,
         timeout=20,
     )

--- a/cgi_clinics_api/sequencing.py
+++ b/cgi_clinics_api/sequencing.py
@@ -356,7 +356,7 @@ def delete_sequencing(
     project_uuid: str,
     sequencing_uuid: str,
     main_headers: dict[str, str],
-) -> dict:
+) -> None:
     """Delete a sequencing from the new CGI-Clinics Platform.
 
     Parameters
@@ -370,8 +370,8 @@ def delete_sequencing(
 
     Returns
     -------
-    dict
-        A dictionary containing the sequencing information.
+    None
+        This function doesn't return anything.
 
     Raises
     ------
@@ -390,8 +390,7 @@ def delete_sequencing(
             f"Failed to delete sequencing (Error {response.status_code}): {response.text}"
         )
     print(f"Sequencing deleted successfully: {sequencing_uuid}")
-
-    return response.json()
+    return None
 
 
 # endregion DELETE


### PR DESCRIPTION
This pull request refactors several `delete_*` functions across multiple modules to standardize their behavior by changing their return type to `None` and updating their docstrings accordingly. Additionally, it updates API endpoint URLs in the `sequencing.py` module to include the `project` path segment for consistency with the platform's API structure.

### Standardization of `delete_*` functions:
* Updated the return type of `delete_analysis` in `cgi_clinics_api/analysis.py` to `None` and removed the return statement. Updated the docstring to reflect the new behavior. [[1]](diffhunk://#diff-5104a0869fa2f3622061797ff743cfbaf604b64e2ec98c5bac5f589d738bac98L599-R599) [[2]](diffhunk://#diff-5104a0869fa2f3622061797ff743cfbaf604b64e2ec98c5bac5f589d738bac98L613-R614) [[3]](diffhunk://#diff-5104a0869fa2f3622061797ff743cfbaf604b64e2ec98c5bac5f589d738bac98L631-R631)
* Updated the return type of `delete_patient` in `cgi_clinics_api/patient.py` to `None` and removed the return statement. Updated the docstring to reflect the new behavior. [[1]](diffhunk://#diff-aa488406356187fcce4bec88e1cc0436f0a2a9bb0289d818600cb78947f21b26L439-R439) [[2]](diffhunk://#diff-aa488406356187fcce4bec88e1cc0436f0a2a9bb0289d818600cb78947f21b26L453-R454) [[3]](diffhunk://#diff-aa488406356187fcce4bec88e1cc0436f0a2a9bb0289d818600cb78947f21b26L471-R471)
* Updated the return type of `delete_project` in `cgi_clinics_api/project.py` to `None` and removed the return statement. Updated the docstring to reflect the new behavior. [[1]](diffhunk://#diff-5980a1bf07df45f2302fa69f7d784c607ff87e4ee2fc28b5a2193bf222ca3412L175-R175) [[2]](diffhunk://#diff-5980a1bf07df45f2302fa69f7d784c607ff87e4ee2fc28b5a2193bf222ca3412L187-R188) [[3]](diffhunk://#diff-5980a1bf07df45f2302fa69f7d784c607ff87e4ee2fc28b5a2193bf222ca3412L203-R203)
* Updated the return type of `delete_sample` in `cgi_clinics_api/sample.py` to `None` and removed the return statement. Updated the docstring to reflect the new behavior. [[1]](diffhunk://#diff-379d4143a3d336df51d8f8270b153f5d234d664c8badb4c628de79c735eb85f2L388-R388) [[2]](diffhunk://#diff-379d4143a3d336df51d8f8270b153f5d234d664c8badb4c628de79c735eb85f2L402-R403) [[3]](diffhunk://#diff-379d4143a3d336df51d8f8270b153f5d234d664c8badb4c628de79c735eb85f2L420-R421)
* Updated the return type of `delete_sequencing` in `cgi_clinics_api/sequencing.py` to `None` and removed the return statement. Updated the docstring to reflect the new behavior. [[1]](diffhunk://#diff-bab904a55120d0b5088b998456b1a94db995ed4b4144420a093872be08495bfeL359-R359) [[2]](diffhunk://#diff-bab904a55120d0b5088b998456b1a94db995ed4b4144420a093872be08495bfeL373-R374) [[3]](diffhunk://#diff-bab904a55120d0b5088b998456b1a94db995ed4b4144420a093872be08495bfeL393-R393)

### API endpoint updates in `sequencing.py`:
* Updated the API endpoint URLs in `get_all_sequencings_paginated`, `get_sequencing_by_uuid`, `create_sequencing`, `update_sequencing`, and `delete_sequencing` to include the `project` path segment for consistency. [[1]](diffhunk://#diff-bab904a55120d0b5088b998456b1a94db995ed4b4144420a093872be08495bfeL111-R111) [[2]](diffhunk://#diff-bab904a55120d0b5088b998456b1a94db995ed4b4144420a093872be08495bfeL151-R151) [[3]](diffhunk://#diff-bab904a55120d0b5088b998456b1a94db995ed4b4144420a093872be08495bfeL241-R241) [[4]](diffhunk://#diff-bab904a55120d0b5088b998456b1a94db995ed4b4144420a093872be08495bfeL333-R333) [[5]](diffhunk://#diff-bab904a55120d0b5088b998456b1a94db995ed4b4144420a093872be08495bfeL383-R383)