### PR TITLE
[PATCH] Add required `informed_consent=True` in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ This module provides functions to interact with sequencing type-related endpoint
 >         sequencing_type=sequencing_type,
 >         reference_genome=reference_genome,
 >         sequencing_germline_control="YES",
+>         informed_consent=True,
 >         input_files=input_files
 >     )
 >     print(f"Analysis created: {analysis_result.get('uuid')}")


### PR DESCRIPTION
The example in the README didn't have the `informed_consent` parameter added, which is a required field to run that function. This PR adds it.